### PR TITLE
Add HACS + hassfest validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,37 @@
+name: Validate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
+    name: Hassfest validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Run hassfest validation
+        uses: home-assistant/actions/hassfest@master
+
+  hacs: # https://github.com/hacs/action
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/custom_components/waterlevel_ie/manifest.json
+++ b/custom_components/waterlevel_ie/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "waterlevel_ie",
   "name": "WaterLevel.ie",
-  "version": "1.8.1",
-  "documentation": "https://github.com/tuckshoprn/waterlevel_ie",
-  "issue_tracker": "https://github.com/tuckshoprn/waterlevel_ie/issues",
-  "requirements": [],
-  "dependencies": [],
   "codeowners": [
     "@tuckshoprn"
   ],
-  "iot_class": "cloud_polling",
   "config_flow": true,
-  "single_config_entry": true
+  "dependencies": [],
+  "documentation": "https://github.com/tuckshoprn/waterlevel_ie",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/tuckshoprn/waterlevel_ie/issues",
+  "requirements": [],
+  "single_config_entry": true,
+  "version": "1.8.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "WaterLevel.ie",
   "hacs": "1.6.0",
-  "domains": ["sensor", "binary_sensor"],
-  "iot_class": "Cloud Polling",
   "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
Adds hassfest + HACS validation (category: integration) running on push, PR, and a daily schedule, in preparation for HACS default-store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)